### PR TITLE
feat: 게시글 좋아요 등록 및 삭제

### DIFF
--- a/src/main/java/com/sparta/newsfeed/post/entity/Post.java
+++ b/src/main/java/com/sparta/newsfeed/post/entity/Post.java
@@ -27,7 +27,4 @@ public class Post extends Timestamped {
     @JoinColumn(name="user_id", nullable=false)
     private User user;
 
-    private List<Comment> comments;
-
-    private List<PostLike> likes;
 }

--- a/src/main/java/com/sparta/newsfeed/postlike/controller/PostLikeController.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/controller/PostLikeController.java
@@ -1,13 +1,28 @@
 package com.sparta.newsfeed.postlike.controller;
 
+import com.sparta.newsfeed.postlike.dto.PostLikeRequestDto;
+import com.sparta.newsfeed.postlike.entity.PostLike;
 import com.sparta.newsfeed.postlike.service.PostLikeService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping()
+@RequestMapping("/api/v1/postlikes")
 public class PostLikeController {
     private final PostLikeService postLikeService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping
+    public void postLike(HttpServletRequest request, @RequestBody PostLikeRequestDto postLikeRequestDto) {
+        postLikeService.postLike(request, postLikeRequestDto);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{postLikeId}")
+    public void deletePostLike(HttpServletRequest request, @PathVariable Long postLikeId) {
+        postLikeService.deletePostLike(request, postLikeId);
+    }
 }

--- a/src/main/java/com/sparta/newsfeed/postlike/controller/PostLikeController.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/controller/PostLikeController.java
@@ -10,12 +10,12 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/postlikes")
+@RequestMapping("/api/v1")
 public class PostLikeController {
     private final PostLikeService postLikeService;
 
-    @ResponseStatus(HttpStatus.OK)
-    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/postlikes")
     public void postLike(HttpServletRequest request, @RequestBody PostLikeRequestDto postLikeRequestDto) {
         postLikeService.postLike(request, postLikeRequestDto);
     }

--- a/src/main/java/com/sparta/newsfeed/postlike/dto/PostLikeRequestDto.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/dto/PostLikeRequestDto.java
@@ -1,0 +1,8 @@
+package com.sparta.newsfeed.postlike.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostLikeRequestDto {
+    private Long postId;
+}

--- a/src/main/java/com/sparta/newsfeed/postlike/entity/PostLike.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/entity/PostLike.java
@@ -4,9 +4,11 @@ import com.sparta.newsfeed.post.entity.Post;
 import com.sparta.newsfeed.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class PostLike {
 
     @Id
@@ -20,4 +22,9 @@ public class PostLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    public PostLike(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
 }

--- a/src/main/java/com/sparta/newsfeed/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/repository/PostLikeRepository.java
@@ -1,7 +1,12 @@
 package com.sparta.newsfeed.postlike.repository;
 
+import com.sparta.newsfeed.post.entity.Post;
 import com.sparta.newsfeed.postlike.entity.PostLike;
+import com.sparta.newsfeed.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    boolean existsByUserAndPost(User user, Post post);
 }

--- a/src/main/java/com/sparta/newsfeed/postlike/service/PostLikeService.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/service/PostLikeService.java
@@ -1,6 +1,18 @@
 package com.sparta.newsfeed.postlike.service;
 
+import com.sparta.newsfeed.commentlike.repository.CommentLikeRepository;
+import com.sparta.newsfeed.common.config.JwtUtil;
+import com.sparta.newsfeed.common.exception.ApplicationException;
+import com.sparta.newsfeed.common.exception.ErrorCode;
+import com.sparta.newsfeed.post.entity.Post;
+import com.sparta.newsfeed.post.repository.PostRepository;
+import com.sparta.newsfeed.postlike.dto.PostLikeRequestDto;
+import com.sparta.newsfeed.postlike.entity.PostLike;
 import com.sparta.newsfeed.postlike.repository.PostLikeRepository;
+import com.sparta.newsfeed.user.entity.User;
+import com.sparta.newsfeed.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,4 +20,47 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PostLikeService {
     private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final CommentLikeRepository commentLikeRepository;
+
+    @Transactional
+    public void postLike(HttpServletRequest request, PostLikeRequestDto postLikeRequestDto) {
+        // JWT를 사용하여 유저 검색
+        User user = userRepository.findById(getUserId(request)).orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        // postId로 Post 검색
+        Post post = postRepository.findById(postLikeRequestDto.getPostId()).orElseThrow(() -> new ApplicationException(ErrorCode.POST_NOT_FOUND));
+
+        // user가 post에 좋아요를 한 상태인가?
+        boolean alreadyLiked = postLikeRepository.existsByUserAndPost(user, post);
+
+        // 좋아요를 누른 상태가 아니라면
+        if(!alreadyLiked) {
+            // 좋아요 등록
+            PostLike postLike = new PostLike(user, post);
+            postLikeRepository.save(postLike);
+        }
+    }
+
+    public void deletePostLike(HttpServletRequest request, Long postLikeId) {
+        // JWT를 사용하여 유저 검색
+        User user = userRepository.findById(getUserId(request)).orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        // postLikeId로 Post 검색
+        PostLike postLike = postLikeRepository.findById(postLikeId).orElseThrow(() -> new ApplicationException(ErrorCode.POST_NOT_FOUND));
+
+        // postLike의 유저 정보가 user와 같다면.
+        if(postLike.getUser().getId().equals(user.getId())) {
+            postLikeRepository.delete(postLike);
+        }
+    }
+
+    public Long getUserId(HttpServletRequest request)
+    {
+        String token = jwtUtil.getJwtFromHeader(request);
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        return userId;
+    }
 }

--- a/src/main/java/com/sparta/newsfeed/user/entity/User.java
+++ b/src/main/java/com/sparta/newsfeed/user/entity/User.java
@@ -1,14 +1,17 @@
 package com.sparta.newsfeed.user.entity;
 
+import com.sparta.newsfeed.common.Timestamped;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-import java.util.List;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(name = "users")
-public class User {
+public class User extends Timestamped {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,6 +28,16 @@ public class User {
     @Column(nullable = false)
     private String password;
 
+    private boolean isEnabled = false;
 
-    //private List<User> friends;
+    public User(String email, String password, String nickname, String introduction) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.introduction = introduction;
+    }
+
+    public void delete() {
+        this.isEnabled = true;
+    }
 }


### PR DESCRIPTION
게시글(Post)에 좋아요를 등록 및 삭제 하는 기능을 추가했습니다.

**좋아요 등록** : 전달받은 토큰의 UserId와 request로 전달받은 PostId로 
좋아요를 등록하고자 하는 User와 좋아요를 등록할 Post를 검색한 뒤
좋아요를 누른 상태가 아니라면 좋아요를 등록합니다.

**좋아요 삭제** :  전달받은  토큰의 UserId와 URL로 전달받은 postLikeId로
좋아요를 삭제하고자 하는 User와 등록했던 PostLike 를 검색한 뒤
PostLike의 UserId와 User의 UserId가 일치한다면 PostLike를 삭제합니다.