### PR TITLE
feat: 댓글 좋아요 등록 및 삭제, 수정사항 반영

### DIFF
--- a/src/main/java/com/sparta/newsfeed/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/newsfeed/comment/controller/CommentController.java
@@ -16,28 +16,29 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
     private final CommentService commentService;
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{postId}")
-    public ResponseEntity<CommentResponseDto> createComment(@PathVariable Long postId, HttpServletRequest request, @RequestBody CommentRequestDto commentRequestDto) {
-        return ResponseEntity.ok(commentService.createComment(postId, request, commentRequestDto));
+    public CommentResponseDto createComment(@PathVariable Long postId, HttpServletRequest request, @RequestBody CommentRequestDto commentRequestDto) {
+        return commentService.createComment(postId, request, commentRequestDto);
     }
 
+    @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{commentId}")
-    public ResponseEntity<CommentResponseDto> getComment(@PathVariable Long commentId) {
-        return ResponseEntity.ok(commentService.getComment(commentId));
+    public CommentResponseDto getComment(@PathVariable Long commentId) {
+        return commentService.getComment(commentId);
     }
-
 
     // 댓글의 수정은 댓글의 작성자 혹은 게시글의 작성자만 가능. 사용자 정보, 게시글 정보
+    @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{commentId}")
-    public ResponseEntity<CommentResponseDto> updateComment(@PathVariable Long commentId, @RequestBody CommentRequestDto commentRequestDto) {
-        return ResponseEntity.ok(commentService.updateComment(commentId, commentRequestDto));
+    public CommentResponseDto updateComment(@PathVariable Long commentId, @RequestBody CommentRequestDto commentRequestDto) {
+        return commentService.updateComment(commentId, commentRequestDto);
     }
 
-
     //댓글의 삭제는 댓글의 작성자 혹은 게시글의 작성자만 가능.
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
+    public void deleteComment(@PathVariable Long commentId) {
         commentService.deleteComment(commentId);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/sparta/newsfeed/commentlike/controller/CommentLikeController.java
+++ b/src/main/java/com/sparta/newsfeed/commentlike/controller/CommentLikeController.java
@@ -1,13 +1,27 @@
 package com.sparta.newsfeed.commentlike.controller;
 
+import com.sparta.newsfeed.commentlike.dto.CommentLikeRequestDto;
 import com.sparta.newsfeed.commentlike.service.CommentLikeService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping()
+@RequestMapping("/api/v1/commentlikes")
 public class CommentLikeController {
     private final CommentLikeService commentLikeService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/commentlikes")
+    public void commentLike(HttpServletRequest request, @RequestBody CommentLikeRequestDto commentLikeRequestDto) {
+        commentLikeService.commentLike(request, commentLikeRequestDto);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/commentlikes/{postLikeId}")
+    public void deleteCommentLike(HttpServletRequest request, @PathVariable Long commentLikeId) {
+        commentLikeService.deleteCommentLike(request, commentLikeId);
+    }
 }

--- a/src/main/java/com/sparta/newsfeed/commentlike/dto/CommentLikeRequestDto.java
+++ b/src/main/java/com/sparta/newsfeed/commentlike/dto/CommentLikeRequestDto.java
@@ -1,0 +1,8 @@
+package com.sparta.newsfeed.commentlike.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CommentLikeRequestDto {
+    private Long commentId;
+}

--- a/src/main/java/com/sparta/newsfeed/commentlike/entity/CommentLike.java
+++ b/src/main/java/com/sparta/newsfeed/commentlike/entity/CommentLike.java
@@ -20,4 +20,9 @@ public class CommentLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
+
+    public CommentLike(User user, Comment comment) {
+        this.user = user;
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/sparta/newsfeed/commentlike/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sparta/newsfeed/commentlike/repository/CommentLikeRepository.java
@@ -1,9 +1,12 @@
 package com.sparta.newsfeed.commentlike.repository;
 
+import com.sparta.newsfeed.comment.entity.Comment;
 import com.sparta.newsfeed.commentlike.entity.CommentLike;
+import com.sparta.newsfeed.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    boolean existsByUserAndComment(User user, Comment comment);
 }

--- a/src/main/java/com/sparta/newsfeed/commentlike/service/CommentLikeService.java
+++ b/src/main/java/com/sparta/newsfeed/commentlike/service/CommentLikeService.java
@@ -1,6 +1,18 @@
 package com.sparta.newsfeed.commentlike.service;
 
+import com.sparta.newsfeed.comment.entity.Comment;
+import com.sparta.newsfeed.comment.repository.CommentRepository;
+import com.sparta.newsfeed.commentlike.dto.CommentLikeRequestDto;
+import com.sparta.newsfeed.commentlike.entity.CommentLike;
 import com.sparta.newsfeed.commentlike.repository.CommentLikeRepository;
+import com.sparta.newsfeed.common.config.JwtUtil;
+import com.sparta.newsfeed.common.exception.ApplicationException;
+import com.sparta.newsfeed.common.exception.ErrorCode;
+import com.sparta.newsfeed.post.entity.Post;
+import com.sparta.newsfeed.postlike.entity.PostLike;
+import com.sparta.newsfeed.user.entity.User;
+import com.sparta.newsfeed.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,4 +20,47 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CommentLikeService {
     private final CommentLikeRepository commentLikeRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    public void commentLike(HttpServletRequest request, CommentLikeRequestDto commentLikeRequestDto) {
+        // JWT를 사용하여 유저 검색
+        User user = userRepository.findById(getUserId(request)).orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        // commentId로 Comment 검색
+        Comment comment  = commentRepository.findById(commentLikeRequestDto.getCommentId()).orElseThrow(() -> new ApplicationException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // user가 comment에 좋아요를 한 상태인가?
+        boolean alreadyLiked = commentLikeRepository.existsByUserAndComment(user, comment);
+
+        // 좋아요를 누른 상태가 아니라면
+        if(!alreadyLiked) {
+            // 좋아요 등록
+            CommentLike commentLike = new CommentLike(user, comment);
+            commentLikeRepository.save(commentLike);
+        }else{
+            throw new ApplicationException(ErrorCode.COMMENT_ALREADY_LIKED);
+        }
+    }
+
+    public void deleteCommentLike(HttpServletRequest request, Long commentLikeId) {
+        // JWT를 사용하여 유저 검색
+        User user = userRepository.findById(getUserId(request)).orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        // commentLikeId로 Comment 검색
+        CommentLike commentLike = commentLikeRepository.findById(commentLikeId).orElseThrow(() -> new ApplicationException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // commentLike의 유저 정보가 user와 같다면.
+        if(commentLike.getUser().getId().equals(user.getId())) {
+            commentLikeRepository.delete(commentLike);
+        }
+    }
+
+    public Long getUserId(HttpServletRequest request)
+    {
+        String token = jwtUtil.getJwtFromHeader(request);
+        Long userId = jwtUtil.getUserIdFromToken(token);
+        return userId;
+    }
 }

--- a/src/main/java/com/sparta/newsfeed/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/newsfeed/common/exception/ErrorCode.java
@@ -5,6 +5,8 @@ public enum ErrorCode {
     BAD_REQUEST(400, "잘못된 요청입니다."),
     COMMENT_NOT_FOUND(404, "존재하지 않는 댓글입니다."),
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
+    POST_ALREADY_LIKED(404, "이미 좋아요를 누른 게시물입니다."),
+    COMMENT_ALREADY_LIKED(404, "이미 좋아요를 누른 댓글입니다."),
     POST_NOT_FOUND(404, "존재하지 않는 게시물입니다.");
 
 

--- a/src/main/java/com/sparta/newsfeed/postlike/controller/PostLikeController.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/controller/PostLikeController.java
@@ -21,7 +21,7 @@ public class PostLikeController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/{postLikeId}")
+    @DeleteMapping("/postlilkes/{postLikeId}")
     public void deletePostLike(HttpServletRequest request, @PathVariable Long postLikeId) {
         postLikeService.deletePostLike(request, postLikeId);
     }

--- a/src/main/java/com/sparta/newsfeed/postlike/service/PostLikeService.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/service/PostLikeService.java
@@ -41,6 +41,8 @@ public class PostLikeService {
             // 좋아요 등록
             PostLike postLike = new PostLike(user, post);
             postLikeRepository.save(postLike);
+        }else{
+            throw new ApplicationException(ErrorCode.POST_ALREADY_LIKED);
         }
     }
 


### PR DESCRIPTION
댓글(Comment)에 좋아요를 등록 및 삭제 하는 기능을 추가했습니다.

좋아요 등록 : 전달받은 토큰의 UserId와 request로 전달받은 CommentId로
좋아요를 등록하고자 하는 User와 좋아요를 등록할 Comment를 검색한 뒤
좋아요를 누른 상태가 아니라면 좋아요를 등록합니다.

좋아요 삭제 : 전달받은 토큰의 UserId와 URL로 전달받은 commentLikeId로
좋아요를 삭제하고자 하는 User와 등록했던 CommentLike 를 검색한 뒤
CommentLike의 UserId와 User의 UserId가 일치한다면 CommentLike를 삭제합니다.