### PR TITLE
refactor: Comment 수정 및 삭제, CommentLike, PostLike 요청에 대한 권한 처리

### DIFF
--- a/src/main/java/com/sparta/newsfeed/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/newsfeed/comment/controller/CommentController.java
@@ -31,14 +31,14 @@ public class CommentController {
     // 댓글의 수정은 댓글의 작성자 혹은 게시글의 작성자만 가능. 사용자 정보, 게시글 정보
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{commentId}")
-    public void updateComment(@PathVariable Long commentId, @RequestBody CommentRequestDto commentRequestDto) {
-        commentService.updateComment(commentId, commentRequestDto);
+    public void updateComment(HttpServletRequest request, @PathVariable Long commentId, @RequestBody CommentRequestDto commentRequestDto) {
+        commentService.updateComment(request, commentId, commentRequestDto);
     }
 
     //댓글의 삭제는 댓글의 작성자 혹은 게시글의 작성자만 가능.
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/{commentId}")
-    public void deleteComment(@PathVariable Long commentId) {
-        commentService.deleteComment(commentId);
+    public void deleteComment(HttpServletRequest request, @PathVariable Long commentId) {
+        commentService.deleteComment(request, commentId);
     }
 }

--- a/src/main/java/com/sparta/newsfeed/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/newsfeed/comment/controller/CommentController.java
@@ -18,8 +18,8 @@ public class CommentController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{postId}")
-    public CommentResponseDto createComment(@PathVariable Long postId, HttpServletRequest request, @RequestBody CommentRequestDto commentRequestDto) {
-        return commentService.createComment(postId, request, commentRequestDto);
+    public void createComment(@PathVariable Long postId, HttpServletRequest request, @RequestBody CommentRequestDto commentRequestDto) {
+        commentService.createComment(postId, request, commentRequestDto);
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -31,8 +31,8 @@ public class CommentController {
     // 댓글의 수정은 댓글의 작성자 혹은 게시글의 작성자만 가능. 사용자 정보, 게시글 정보
     @ResponseStatus(HttpStatus.OK)
     @PutMapping("/{commentId}")
-    public CommentResponseDto updateComment(@PathVariable Long commentId, @RequestBody CommentRequestDto commentRequestDto) {
-        return commentService.updateComment(commentId, commentRequestDto);
+    public void updateComment(@PathVariable Long commentId, @RequestBody CommentRequestDto commentRequestDto) {
+        commentService.updateComment(commentId, commentRequestDto);
     }
 
     //댓글의 삭제는 댓글의 작성자 혹은 게시글의 작성자만 가능.

--- a/src/main/java/com/sparta/newsfeed/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/newsfeed/comment/dto/CommentResponseDto.java
@@ -7,9 +7,11 @@ import lombok.Getter;
 public class CommentResponseDto {
     private String nickname;
     private String content;
+    private int likeCount;
 
-    public CommentResponseDto(Comment comment){
+    public CommentResponseDto(Comment comment, int likeCount){
         this.nickname = comment.getUser().getNickname();
         this.content = comment.getContent();
+        this.likeCount = likeCount;
     }
 }

--- a/src/main/java/com/sparta/newsfeed/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/newsfeed/comment/service/CommentService.java
@@ -12,6 +12,7 @@ import com.sparta.newsfeed.post.entity.Post;
 import com.sparta.newsfeed.post.repository.PostRepository;
 import com.sparta.newsfeed.user.entity.User;
 import com.sparta.newsfeed.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -50,19 +51,38 @@ public class CommentService {
     }
 
     @Transactional
-    public void updateComment(Long commentId, CommentRequestDto commentRequestDto) {
+    public void updateComment(HttpServletRequest request, Long commentId, CommentRequestDto commentRequestDto) {
+        // 댓글은 작성자 혹은 게시물의 작성자만 수정이 가능합니다.
+        User user = userRepository.findById(getUserId(request)).orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
         Comment comment = findComment(commentId);
 
-        comment.update(commentRequestDto.getContent());
-
+        // 댓글 작성자의 Id와 사용자의 Id, 게시물 작성자의 Id와 비교
+        if((user.getId() == comment.getUser().getId()) || (user.getId() == comment.getPost().getId())) {
+            // 수정을 요청한 유저Id가 댓글의 유저Id 또는 게시물의 유저Id와 일치한다면 -> 수정 가능
+            comment.update(commentRequestDto.getContent());
+        }else{
+            // Id가 일치하지 않으면 -> 수정 불가
+            throw new ApplicationException(ErrorCode.USER_CANNOTUPDATE_COMMENT);
+        }
         commentRepository.save(comment);
     }
 
     @Transactional
-    public void deleteComment(Long commentId) {
+    public void deleteComment(HttpServletRequest request, Long commentId) {
+        // 댓글은 작성자 혹은 게시물의 작성자만 수정이 가능합니다.
+        User user = userRepository.findById(getUserId(request)).orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
         Comment comment = findComment(commentId);
 
-        commentRepository.delete(comment);
+        // 댓글 작성자의 Id와 사용자의 Id, 게시물 작성자의 Id와 비교
+        if((user.getId() == comment.getUser().getId()) || (user.getId() == comment.getPost().getId())) {
+            // 삭제을 요청한 유저Id가 댓글의 유저Id 또는 게시물의 유저Id와 일치한다면 -> 삭제 가능
+            commentRepository.delete(comment);
+        }else{
+            // Id가 일치하지 않으면 -> 수정 불가
+            throw new ApplicationException(ErrorCode.USER_CANNOTDELETE_COMMENT);
+        }
     }
 
     public Comment findComment(Long commentId) {

--- a/src/main/java/com/sparta/newsfeed/commentlike/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sparta/newsfeed/commentlike/repository/CommentLikeRepository.java
@@ -6,7 +6,11 @@ import com.sparta.newsfeed.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
     boolean existsByUserAndComment(User user, Comment comment);
+
+    List<CommentLike> findByComment(Comment comment);
 }

--- a/src/main/java/com/sparta/newsfeed/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/newsfeed/common/exception/ErrorCode.java
@@ -4,6 +4,8 @@ public enum ErrorCode {
 
     BAD_REQUEST(400, "잘못된 요청입니다."),
     UNSUPPORTED_SORT_CRITERIA(400, "지원하지 않는 정렬 기준입니다."),
+    USER_CANNOTUPDATE_COMMENT(404, "댓글 수정 권한이 없습니다."),
+    USER_CANNOTDELETE_COMMENT(404, "댓글 삭제 권한이 없습니다."),
     USER_CANNOTLIKE_OWNCOMMENT(404, "유저는 본인의 댓글에 좋아요를 누를 수 없습니다."),
     USER_CANNOTLIKE_OWNPOST(404, "유저는 본인의 게시물에 좋아요를 누를 수 없습니다."),
 

--- a/src/main/java/com/sparta/newsfeed/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/newsfeed/common/exception/ErrorCode.java
@@ -4,6 +4,8 @@ public enum ErrorCode {
 
     BAD_REQUEST(400, "잘못된 요청입니다."),
     UNSUPPORTED_SORT_CRITERIA(400, "지원하지 않는 정렬 기준입니다."),
+    USER_CANNOTLIKE_OWNCOMMENT(404, "유저는 본인의 댓글에 좋아요를 누를 수 없습니다."),
+    USER_CANNOTLIKE_OWNPOST(404, "유저는 본인의 게시물에 좋아요를 누를 수 없습니다."),
 
     USER_NOT_FOUND(404, "존재하지 않는 유저입니다."),
     POST_NOT_FOUND(404, "존재하지 않는 게시물입니다."),

--- a/src/main/java/com/sparta/newsfeed/postlike/repository/PostLikeRepository.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/repository/PostLikeRepository.java
@@ -5,8 +5,11 @@ import com.sparta.newsfeed.postlike.entity.PostLike;
 import com.sparta.newsfeed.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     boolean existsByUserAndPost(User user, Post post);
+
+    List<PostLike> findByPost(Post post);
 }


### PR DESCRIPTION
API 명세서의 return 에 맞게 Controller 반환타입 수정.

Post와 Comment에 대한 좋아요 요청시 요청한 User의 Id값과 Post와 Comment의 작성자 User의 Id 값을 
비교하여 본인이 작성한 Post와 Comment에 대한 좋아요 요청시 예외처리를 해주었습니다.

Comment 수정 및 삭제 요청은 Comment의 작성자 또는 Post의 작성자의 경우에만 가능하도록 수정했습니다.