### PR TITLE
refactor: Comment soft delete 리팩토링, 오타 수정

### DIFF
--- a/src/main/java/com/sparta/newsfeed/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/newsfeed/comment/controller/CommentController.java
@@ -18,35 +18,35 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/comments")
+@RequestMapping("/api/v1/posts")
 public class CommentController {
 
     private final CommentService commentService;
 
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/{postId}")
+    @PostMapping("/{postId}/comments")
     public void createComment(@PathVariable Long postId, HttpServletRequest request,
             @RequestBody CommentRequestDto commentRequestDto) {
         commentService.createComment(postId, request, commentRequestDto);
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/{commentId}")
+    @GetMapping("/comments/{commentId}")
     public CommentResponseDto getComment(@PathVariable Long commentId) {
         return commentService.getComment(commentId);
     }
 
     // 댓글의 수정은 댓글의 작성자 혹은 게시글의 작성자만 가능. 사용자 정보, 게시글 정보
     @ResponseStatus(HttpStatus.OK)
-    @PutMapping("/{commentId}")
+    @PutMapping("/comments/{commentId}")
     public void updateComment(HttpServletRequest request, @PathVariable Long commentId,
             @RequestBody CommentRequestDto commentRequestDto) {
         commentService.updateComment(request, commentId, commentRequestDto);
     }
 
-    //댓글의 삭제는 댓글의 작성자 혹은 게시글의 작성자만 가능.
+    //댓글의 삭제는 댓글의 작성자 혹은 게시글의 작성자만 가능. -> softdelete
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/{commentId}")
+    @DeleteMapping("/comments/{commentId}")
     public void deleteComment(HttpServletRequest request, @PathVariable Long commentId) {
         commentService.deleteComment(request, commentId);
     }

--- a/src/main/java/com/sparta/newsfeed/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/sparta/newsfeed/comment/dto/CommentRequestDto.java
@@ -1,8 +1,10 @@
 package com.sparta.newsfeed.comment.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class CommentRequestDto {
 
     private String content;

--- a/src/main/java/com/sparta/newsfeed/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/sparta/newsfeed/comment/dto/CommentResponseDto.java
@@ -2,8 +2,10 @@ package com.sparta.newsfeed.comment.dto;
 
 import com.sparta.newsfeed.comment.entity.Comment;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class CommentResponseDto {
 
     private String nickname;

--- a/src/main/java/com/sparta/newsfeed/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/newsfeed/comment/repository/CommentRepository.java
@@ -2,6 +2,9 @@ package com.sparta.newsfeed.comment.repository;
 
 import com.sparta.newsfeed.comment.entity.Comment;
 import java.util.List;
+import java.util.Optional;
+
+import com.sparta.newsfeed.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByPostIdAndIsDeletedIsFalse(final Long postId);
+
+    Optional<Comment> findByIdAndIsDeletedIsFalse(final Long id);
 }

--- a/src/main/java/com/sparta/newsfeed/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/newsfeed/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import com.sparta.newsfeed.comment.dto.CommentRequestDto;
 import com.sparta.newsfeed.comment.dto.CommentResponseDto;
 import com.sparta.newsfeed.comment.entity.Comment;
 import com.sparta.newsfeed.comment.repository.CommentRepository;
+import com.sparta.newsfeed.commentlike.repository.CommentLikeRepository;
 import com.sparta.newsfeed.commentlike.service.CommentLikeService;
 import com.sparta.newsfeed.common.config.JwtUtil;
 import com.sparta.newsfeed.common.exception.ApplicationException;
@@ -24,6 +25,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final CommentLikeRepository commentLikeRepository;
     private final CommentLikeService commentLikeService;
     private final JwtUtil jwtUtil;
 
@@ -75,12 +77,17 @@ public class CommentService {
         User user = userRepository.findById(getUserId(request))
                 .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
 
-        Comment comment = findComment(commentId);
+        // 삭제하고자 하는 Comment의 IsDeleted 상태가 False인지 판별 아니라면 예외 Throw
+        Comment comment = commentRepository.findByIdAndIsDeletedIsFalse(commentId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.COMMENT_NOT_FOUND));;
 
         // 댓글 작성자의 Id와 사용자의 Id, 게시물 작성자의 Id와 비교
         if ((user.getId() == comment.getUser().getId()) || (user.getId() == comment.getPost().getId())) {
             // 삭제을 요청한 유저Id가 댓글의 유저Id 또는 게시물의 유저Id와 일치한다면 -> 삭제 가능
-            commentRepository.delete(comment);
+
+            //comment에 찍힌 좋아요 데이터를 삭제합니다.
+            commentLikeRepository.deleteAllByCommentId(comment.getId());
+            comment.delete();
         } else {
             // Id가 일치하지 않으면 -> 수정 불가
             throw new ApplicationException(ErrorCode.USER_CANNOTDELETE_COMMENT);

--- a/src/main/java/com/sparta/newsfeed/commentlike/controller/CommentLikeController.java
+++ b/src/main/java/com/sparta/newsfeed/commentlike/controller/CommentLikeController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/commentlikes")
+@RequestMapping("/api/v1")
 public class CommentLikeController {
 
     private final CommentLikeService commentLikeService;
@@ -27,7 +27,7 @@ public class CommentLikeController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/commentlikes/{postLikeId}")
+    @DeleteMapping("/commentlikes/{commentLikeId}")
     public void deleteCommentLike(HttpServletRequest request, @PathVariable Long commentLikeId) {
         commentLikeService.deleteCommentLike(request, commentLikeId);
     }

--- a/src/main/java/com/sparta/newsfeed/commentlike/repository/CommentLikeRepository.java
+++ b/src/main/java/com/sparta/newsfeed/commentlike/repository/CommentLikeRepository.java
@@ -15,4 +15,6 @@ public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> 
     List<CommentLike> findByComment(Comment comment);
 
     void deleteAllByCommentIdIn(final List<Long> commentIds);
+
+    void deleteAllByCommentId(final Long commentId);
 }

--- a/src/main/java/com/sparta/newsfeed/postlike/controller/PostLikeController.java
+++ b/src/main/java/com/sparta/newsfeed/postlike/controller/PostLikeController.java
@@ -27,7 +27,7 @@ public class PostLikeController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @DeleteMapping("/postlilkes/{postLikeId}")
+    @DeleteMapping("/postlikes/{postLikeId}")
     public void deletePostLike(HttpServletRequest request, @PathVariable Long postLikeId) {
         postLikeService.deletePostLike(request, postLikeId);
     }


### PR DESCRIPTION
Comment삭제 기능을 soft delete 에 맞게 리팩토링을 진행하였습니다,

Comment comment = commentRepository.findByIdAndIsDeletedIsFalse(commentId)
                .orElseThrow(() -> new ApplicationException(ErrorCode.COMMENT_NOT_FOUND));

위와 같이 삭제 요청시 전달받은 commentId 값을 보유한 comment의 삭제 여부를 판별하는 코드를 추가하여 

삭제가 가능한 상태일 경우 Comment 클래스 내부의 delete()메소드를 호출했습니다.
